### PR TITLE
Set start method to spawn for multiprocessing if gpu available

### DIFF
--- a/cell_type_mapping_tree/src/hierarchical_mapping/cli/from_specified_markers.py
+++ b/cell_type_mapping_tree/src/hierarchical_mapping/cli/from_specified_markers.py
@@ -42,6 +42,16 @@ from hierarchical_mapping.cli.schemas import (
     HierarchicalTypeAssignmentSchema,
     PrecomputedStatsSchema)
 
+try:
+    TORCH_AVAILABLE = False
+    import torch  # type: ignore
+    if torch.cuda.is_available():
+        TORCH_AVAILABLE = True
+        import multiprocessing
+        multiprocessing.set_start_method("spawn", force=True)
+except ImportError:
+    TORCH_AVAILABLE = False
+
 
 class HierarchicalSchemaSpecifiedMarkers(argschema.ArgSchema):
 


### PR DESCRIPTION
Sets multiprocessing's start method to "spawn" if both cuda and gpus are available. 