### PR TITLE
Add validation change property to ValidateH5adRunner

### DIFF
--- a/cell_type_mapping_tree/src/hierarchical_mapping/cli/validate_h5ad.py
+++ b/cell_type_mapping_tree/src/hierarchical_mapping/cli/validate_h5ad.py
@@ -116,7 +116,7 @@ class ValidateH5adRunner(argschema.ArgSchemaParser):
 
         try:
             gene_id_mapper = GeneIdMapper.from_default(log=command_log)
-            result_path = validate_h5ad(
+            result_path, has_warnings = validate_h5ad(
                 h5ad_path=self.args['h5ad_path'],
                 output_dir=self.args['output_dir'],
                 layer=self.args['layer'],
@@ -135,6 +135,7 @@ class ValidateH5adRunner(argschema.ArgSchemaParser):
             output_manifest['log_messages'] = command_log.log
             output_manifest['config'] = self.args
             self.output(output_manifest, indent=2)
+            self.has_warnings = has_warnings
         except Exception:
             traceback_msg = "an ERROR occurred ===="
             traceback_msg += f"\n{traceback.format_exc()}\n"

--- a/cell_type_mapping_tree/src/hierarchical_mapping/validation/validate_h5ad.py
+++ b/cell_type_mapping_tree/src/hierarchical_mapping/validation/validate_h5ad.py
@@ -64,6 +64,8 @@ def validate_h5ad(
     # if that happens, just go ahead and copy and set current_h5ad_path
     # to new_h5ad_path
 
+    has_warnings = False
+
     output_path = None
 
     original_h5ad_path = pathlib.Path(h5ad_path)
@@ -110,6 +112,7 @@ def validate_h5ad(
             log.warn(msg)
         else:
             warnings.warn(msg)
+        has_warnings = True
 
     if mapped_var is not None or not is_int:
         # Copy data over, if it has not already been copied
@@ -145,6 +148,7 @@ def validate_h5ad(
         uns = read_uns_from_h5ad(new_h5ad_path)
         uns['AIBS_CDM_gene_mapping'] = gene_mapping
         write_uns_to_h5ad(new_h5ad_path, uns)
+        has_warnings = True
 
     if not is_int:
         output_dtype = choose_int_dtype(x_minmax)
@@ -159,6 +163,7 @@ def validate_h5ad(
             h5ad_path=new_h5ad_path,
             tmp_dir=tmp_dir,
             output_dtype=output_dtype)
+        has_warnings = True
 
     if log is not None:
         msg = f"DONE VALIDATING {h5ad_path}; "
@@ -172,4 +177,4 @@ def validate_h5ad(
         if new_h5ad_path.exists():
             new_h5ad_path.unlink()
 
-    return output_path
+    return output_path, has_warnings

--- a/cell_type_mapping_tree/tests/validation/test_validate_h5ad.py
+++ b/cell_type_mapping_tree/tests/validation/test_validate_h5ad.py
@@ -19,12 +19,14 @@ from hierarchical_mapping.gene_id.gene_id_mapper import (
 from hierarchical_mapping.validation.validate_h5ad import (
     validate_h5ad)
 
+
 @pytest.fixture(scope='module')
 def tmp_dir_fixture(tmp_path_factory):
     tmp_dir = pathlib.Path(
         tmp_path_factory.mktemp('validating_h5ad_'))
     yield tmp_dir
     _clean_up(tmp_dir)
+
 
 @pytest.fixture
 def map_data_fixture():
@@ -58,6 +60,7 @@ def var_fixture():
 
     return pd.DataFrame(records).set_index('gene_id')
 
+
 @pytest.fixture
 def good_var_fixture():
     records = [
@@ -89,6 +92,7 @@ def x_fixture(var_fixture, obs_fixture):
         for i_col in chosen:
             data[i_row, i_col] = rng.random()*10.0+1.4
     return data
+
 
 @pytest.fixture
 def good_x_fixture(var_fixture, obs_fixture):
@@ -157,7 +161,7 @@ def test_validation_of_h5ad(
     else:
         layer = 'X'
 
-    result_path = validate_h5ad(
+    result_path, _ = validate_h5ad(
         h5ad_path=orig_path,
         output_dir=tmp_dir_fixture,
         gene_id_mapper=gene_id_mapper,
@@ -246,7 +250,7 @@ def test_validation_of_good_h5ad(
 
     gene_id_mapper = GeneIdMapper(data=map_data_fixture)
 
-    result_path = validate_h5ad(
+    result_path, _ = validate_h5ad(
         h5ad_path=orig_path,
         output_dir=tmp_dir_fixture,
         gene_id_mapper=gene_id_mapper,
@@ -260,6 +264,7 @@ def test_validation_of_good_h5ad(
         md51.update(src.read())
 
     assert md50.hexdigest() == md51.hexdigest()
+
 
 @pytest.mark.parametrize(
         "density", ("csr", "csc", "array"))
@@ -301,7 +306,7 @@ def test_validation_of_good_h5ad_in_layer(
 
     gene_id_mapper = GeneIdMapper(data=map_data_fixture)
 
-    result_path = validate_h5ad(
+    result_path, _ = validate_h5ad(
         h5ad_path=orig_path,
         output_dir=tmp_dir_fixture,
         gene_id_mapper=gene_id_mapper,
@@ -394,7 +399,7 @@ def test_validation_of_h5ad_diverse_dtypes(
 
     gene_id_mapper = GeneIdMapper(data=map_data_fixture)
 
-    result_path = validate_h5ad(
+    result_path, _ = validate_h5ad(
         h5ad_path=orig_path,
         output_dir=tmp_dir_fixture,
         gene_id_mapper=gene_id_mapper,


### PR DESCRIPTION
Adds """self.has_warnings = has_warnings""" to cli.validate_h5ad.py. This is used to keep track of validation warnings when the mapping was successful.